### PR TITLE
ci: resolve #58

### DIFF
--- a/.github/workflows/hybridse-ci.yml
+++ b/.github/workflows/hybridse-ci.yml
@@ -31,7 +31,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: cpp-ut-result-${{ github.ref }}
+          name: cpp-ut-result-${{ github.sha }}
           path: |
             build/*.xml
 
@@ -44,7 +44,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: java-ut-result-${{ github.ref }}
+          name: java-ut-result-${{ github.sha }}
           path: |
             java/hybridse-sdk/target/**/TEST-*.xml
 
@@ -86,7 +86,7 @@ jobs:
       - name: Download Cpp Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: cpp-ut-result-${{ github.ref }}
+          name: cpp-ut-result-${{ github.sha }}
           path: cpp-ut-result
 
       - name: Publish Cpp UT Results
@@ -99,7 +99,7 @@ jobs:
       - name: Download Java Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: java-ut-result-${{ github.ref }}
+          name: java-ut-result-${{ github.sha }}
           path: java-ut-result
 
       - name: Publish Java UT Results

--- a/.github/workflows/hybridse-ci.yml
+++ b/.github/workflows/hybridse-ci.yml
@@ -27,26 +27,26 @@ jobs:
         run: |
           ./tools/hybridse_core_test.sh
 
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      - name: Upload Cpp UT Results
         if: always()
+        uses: actions/upload-artifact@v2
         with:
-          files: build/*.xml
-          check_name: Cpp Test Report
-          comment_title: Cpp Test Report
+          name: cpp-ut-result-${{ github.ref }}
+          path: |
+            build/*.xml
 
       - name: Java SDK Test
         run: |
           cd java/
           mvn -U clean compile test
 
-      - name: Publish Java Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      - name: Upload Java UT Results
         if: always()
+        uses: actions/upload-artifact@v2
         with:
-          files: java/hybridse-sdk/target/**/TEST-*.xml
-          check_name: Java Test Report
-          comment_title: Java Test Report
+          name: java-ut-result-${{ github.ref }}
+          path: |
+            java/hybridse-sdk/target/**/TEST-*.xml
 
       - name: Create Archive
         if: ${{ github.event_name == 'push' }}
@@ -75,6 +75,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  publish-test-results:
+    runs-on: ubuntu-latest
+    needs: build
+    # the action will only run on 4paradigm/HybridSE's context
+    if: >
+      always() &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    steps:
+      - name: Download Cpp Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: cpp-ut-result-${{ github.ref }}
+          path: cpp-ut-result
+
+      - name: Publish Cpp UT Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: cpp-ut-result/**/*.xml
+          check_name: Cpp Test Report
+          comment_title: Cpp Test Report
+
+      - name: Download Java Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: java-ut-result-${{ github.ref }}
+          path: java-ut-result
+
+      - name: Publish Java UT Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: java-ut-result/**/*.xml
+          check_name: Java Test Report
+          comment_title: Java Test Report
+
+
   coverage:
     runs-on: ubuntu-latest
     container:
@@ -102,9 +137,3 @@ jobs:
       # cost too much time
       # bash tools/micro_bench.sh | tee micro_bench_report.txt
       # bash tools/gen_micro_bench_compare.sh
-
-      - name: Cleanup
-        if: always()
-        run: |
-          git clean -dfx
-          git submodule foreach 'rm -rf $displaypath'

--- a/.github/workflows/hybridse-ci.yml
+++ b/.github/workflows/hybridse-ci.yml
@@ -78,10 +78,11 @@ jobs:
   publish-test-results:
     runs-on: ubuntu-latest
     needs: build
-    # the action will only run on 4paradigm/HybridSE's context
+    # the action will only run on 4paradigm/HybridSE's context, not for fork repo or dependabot
     if: >
-      always() &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      always() && github.event_name == 'push' || (
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.sender.login != 'dependabot[bot]' )
     steps:
       - name: Download Cpp Artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/publish-test-result-from-fork.yml
+++ b/.github/workflows/publish-test-result-from-fork.yml
@@ -59,13 +59,13 @@ jobs:
       - name: Publish Cpp UT Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
-          files: actifacts/cpp-ut-result-${{ github.ref }}/**/*.xml
+          files: actifacts/cpp-ut-result-*/**/*.xml
           check_name: Cpp Test Report
           comment_title: Cpp Test Report
 
       - name: Publish Java UT Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
-          files: actifacts/java-ut-result-${{ github.ref }}/**/*.xml
+          files: actifacts/java-ut-result-*/**/*.xml
           check_name: Java Test Report
           comment_title: Java Test Report

--- a/.github/workflows/publish-test-result-from-fork.yml
+++ b/.github/workflows/publish-test-result-from-fork.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Publish Cpp UT Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
+          commit: ${{ github.event.workflow_run.head_sha }}
           files: artifacts/cpp-ut-result-*/**/*.xml
           check_name: Cpp Test Report
           comment_title: Cpp Test Report
@@ -66,6 +67,7 @@ jobs:
       - name: Publish Java UT Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
+          commit: ${{ github.event.workflow_run.head_sha }}
           files: artifacts/java-ut-result-*/**/*.xml
           check_name: Java Test Report
           comment_title: Java Test Report

--- a/.github/workflows/publish-test-result-from-fork.yml
+++ b/.github/workflows/publish-test-result-from-fork.yml
@@ -59,13 +59,13 @@ jobs:
       - name: Publish Cpp UT Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
-          files: actifacts/cpp-ut-result-*/**/*.xml
+          files: artifacts/cpp-ut-result-*/**/*.xml
           check_name: Cpp Test Report
           comment_title: Cpp Test Report
 
       - name: Publish Java UT Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
-          files: actifacts/java-ut-result-*/**/*.xml
+          files: artifacts/java-ut-result-*/**/*.xml
           check_name: Java Test Report
           comment_title: Java Test Report

--- a/.github/workflows/publish-test-result-from-fork.yml
+++ b/.github/workflows/publish-test-result-from-fork.yml
@@ -1,0 +1,71 @@
+name: publish-test-result-from-fork
+
+on:
+  # the action will only run on dependabot/fork pull request
+  workflow_run:
+    workflows: ["HybridSE CI"]
+    types:
+      - completed
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion != 'skipped' && (
+         github.event.sender.login == 'dependabot[bot]' ||
+         github.event.workflow_run.head_repository.full_name != github.repository
+      )
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/github-script@v3
+        with:
+          script: |
+            var fs = require('fs');
+            var path = require('path');
+            var artifacts_path = path.join('${{github.workspace}}', 'artifacts')
+            fs.mkdirSync(artifacts_path, { recursive: true })
+
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+
+            for (const artifact of artifacts.data.artifacts) {
+               var download = await github.actions.downloadArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                  archive_format: 'zip',
+               });
+               var artifact_path = path.join(artifacts_path, `${artifact.name}.zip`)
+               fs.writeFileSync(artifact_path, Buffer.from(download.data));
+               console.log(`Downloaded ${artifact_path}`);
+            }
+      - name: Extract Artifacts
+        run: |
+          for file in artifacts/*.zip
+          do
+            if [ -f "$file" ]
+            then
+              dir="${file/%.zip/}"
+              mkdir -p "$dir"
+              unzip -d "$dir" "$file"
+            fi
+          done
+
+      - name: Publish Cpp UT Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: actifacts/cpp-ut-result-${{ github.ref }}/**/*.xml
+          check_name: Cpp Test Report
+          comment_title: Cpp Test Report
+
+      - name: Publish Java UT Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: actifacts/java-ut-result-${{ github.ref }}/**/*.xml
+          check_name: Java Test Report
+          comment_title: Java Test Report


### PR DESCRIPTION
resolve #58 

unit test report now upload as artifacts first, then different action
take between pull request from same repo and forked repo or dependent-bot branch
+ same repo -> publish-test-result action: download artifacts and
  publish
+ fork repo/dependent branch -> publish-test-result-from-fork action: run new
  action on upstream context, download artifacts from fork repo and
  publish

see more at https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches

# Test
Three check should notice
+ ~~UT report published for pr from fork repo~~
   pass at https://github.com/aceforeverd/HybridSE/pull/5
+ ~~UT report published for pr from same repo( different branch)~~
  pass at https://github.com/aceforeverd/HybridSE/pull/2
+ ~~UT report published for push events~~
   pass at https://github.com/aceforeverd/HybridSE/runs/2473481077

# Note
It is possible to only use publish-test-report-from-fork for both forked and local repo. But Since it is triggered by `workflow_run`, which became a bit inconvenient for pr(only work when the action file in the default branch already). And embedded javascript means more unstable and hard to maintain. 

Let's see if we should merge the two job into one in the future. 