### PR TITLE
build: fix maven upload 401 error

### DIFF
--- a/.github/workflows/hybridse-ci.yml
+++ b/.github/workflows/hybridse-ci.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           mvn --batch-mode deploy
         env:
+          MAVEN_OPTS: -Duser.home=/github/home
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
 
@@ -221,6 +222,7 @@ jobs:
         run: |
           mvn --batch-mode deploy -P allinone
         env:
+          MAVEN_OPTS: -Duser.home=/github/home
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_TOKEN: ${{ secrets.OSSRH_TOKEN }}
 


### PR DESCRIPTION
For jobs running in docker container, the actions/setup-java create maven settings file in
`/github/home/.m2/settings.xml`, while maven read settings config from
`/root/.m2/settings.xml`. Then the ossrh info is not loaded. This may a bug in maven.
